### PR TITLE
Use an adhoc supervisor to start the dynamic supervisor and its initial children

### DIFF
--- a/lib/in_stock/application.ex
+++ b/lib/in_stock/application.ex
@@ -15,15 +15,41 @@ defmodule InStock.Application do
       {Phoenix.PubSub, name: InStock.PubSub},
       # Start the Endpoint (http/https)
       InStockWeb.Endpoint,
-      # Start a worker by calling: InStock.Worker.start_link(arg)
-      # {InStock.Worker, arg}
-      InStock.Checker.CheckerSupervisor
+      # Start the Checkers and their supervisors
+      checker_child_spec()
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported option
     opts = [strategy: :one_for_one, name: InStock.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  # Returns a child spec for an ad-hoc supervisor that will start the dynamic
+  # supervisor CheckerSupervisor and then start its initial children
+  #
+  # References:
+  # - https://elixirforum.com/t/understanding-dynamicsupervisor-no-initial-children/14938/2
+  # - https://github.com/slashdotdash/til/blob/master/elixir/dynamic-supervisor-start-children.md
+  defp checker_child_spec() do
+    checker_children = [
+      InStock.Checker.CheckerSupervisor,
+      {Task, &InStock.Checker.CheckerSupervisor.spawn_checkers/0}
+    ]
+
+    checker_opts = [
+      strategy: :rest_for_one,
+      name: InStock.Checker.CheckerStartSupervisor
+    ]
+
+    %{
+      id: InStock.Checker.CheckerStartSupervisor,
+      start: {
+        Supervisor,
+        :start_link,
+        [checker_children, checker_opts]
+      }
+    }
   end
 
   # Tell Phoenix to update the endpoint configuration


### PR DESCRIPTION
Creates an adhoc supervisor which will be started by the Application supervisor, start the dynamic supervisor, and then run a task that starts its children.